### PR TITLE
Use the word decorators instead of annotations

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -19,7 +19,7 @@ a simple language.
 ## Dependencies (for tests)
 
 - Python 2.7+/3+
-- [gradescope-utils](https://github.com/gradescope/gradescope-utils) provides annotations for setting point values for tests, and running tests with a JSON output. [See the Github repository](https://github.com/gradescope/gradescope-utils) for more on what you can do with it, or you can look at the example tests in this project for some usage examples.
+- [gradescope-utils](https://github.com/gradescope/gradescope-utils) provides decorators for setting point values for tests, and running tests with a JSON output. [See the Github repository](https://github.com/gradescope/gradescope-utils) for more on what you can do with it, or you can look at the example tests in this project for some usage examples.
 - subprocess32 is a convenient backport of Python 3.2's subprocess module. Used in one of the tests to communicate with an instance of the REPL to verify that it responds to input correctly.
 
 ### Python 3


### PR DESCRIPTION
Really minor, but I didn't understand what "gradescope-utils provides annotations" meant. I think the word is decorators? Or is annotations a well-known word too?