### PR TITLE
Enhancements to diff_general

### DIFF
--- a/diff_general/.gitignore
+++ b/diff_general/.gitignore
@@ -56,3 +56,4 @@ docs/_build/
 
 # PyBuilder
 target/
+autograder.zip

--- a/diff_general/Makefile
+++ b/diff_general/Makefile
@@ -1,0 +1,2 @@
+all:
+	zip -r autograder.zip *

--- a/diff_general/run_autograder
+++ b/diff_general/run_autograder
@@ -4,4 +4,4 @@ cd /autograder/source
 
 bash ./compile.sh
 
-python run_tests.py > /autograder/results/results.json
+python run_tests.py

--- a/diff_general/run_tests.py
+++ b/diff_general/run_tests.py
@@ -9,4 +9,5 @@ if __name__ == '__main__':
         klass = build_test_class(name)
         suite.addTest(klass(TestMetaclass.test_name(name)))
 
-    JSONTestRunner(visibility='visible').run(suite)
+    with open('/autograder/results/results.json', 'w') as f:
+        JSONTestRunner(stream=f, verbosity=2, visibility='visible', stdout_visibility='visible').run(suite)

--- a/diff_general/test_generator.py
+++ b/diff_general/test_generator.py
@@ -5,6 +5,7 @@ import subprocess32 as subprocess
 from subprocess32 import PIPE
 from gradescope_utils.autograder_utils.decorators import weight
 import yaml
+import difflib
 
 BASE_DIR = './test_data'
 
@@ -51,8 +52,19 @@ class TestMetaclass(type):
             expected_err = load_test_file('err')
 
             msg = settings.get('msg', "Output did not match expected")
+
+            diff = difflib.unified_diff(expected_output.splitlines(True), output.splitlines(True), fromfile='expected_output', tofile='actual_output')
+
+            if diff is not None:
+                msg += "\nThe differences between expected standard output and actual standard output are as follows:\n" + ''.join(diff)
+
             self.assertEqual(expected_output, output, msg=msg)
             if expected_err is not None:
+                diff = difflib.unified_diff(expected_err.splitlines(True), err.splitlines(True), fromfile='expected_err', tofile='actual_err')
+
+                if diff is not None:
+                    msg += "\nThe differences between expected standard error and actual standard error are as follows:\n" + ''.join(diff)
+
                 self.assertEqual(expected_err, err, msg=msg)
         fn.__doc__ = 'Test {0}'.format(dir_name)
         return fn


### PR DESCRIPTION
- Add a Makefile to generate the required zip file.
- Add diffs to user output
  - Replace standard output redirect with direct file write of `results.json`.
    - My hope here was to allow any script output to show up on the webpage but with no avail.
  - Augment message to include diff.