### PR TITLE
Add C++ sample to community resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -15,3 +15,4 @@ Name | Description
 [UCSB Gradescope Tools](https://ucsb-gradescope-tools.github.io/) | Tools and examples for C++ and Python autograders, pulling from GitHub, etc
 [GradescopeGrader4Autolab](https://github.com/xyzisinus/GradescopeGrader4Autolab) | Tools to help port Autolab autograders to Gradescope
 [mnoukhov/gradescope-autograder-template](https://github.com/mnoukhov/gradescope-autograder-template) | An autograder template for Python autograders
+[C++ Configurable Autograder Sample](https://github.com/UgiR/gradescope-autograde-cpp) | Configurable autograder template with C++ tooling


### PR DESCRIPTION
This PR adds a new link to the community resources:

https://github.com/UgiR/gradescope-autograde-cpp

