### PR TITLE
Java example: Put test failure info in JSON output instead of stdout

### DIFF
--- a/java/src/main/java/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
+++ b/java/src/main/java/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
@@ -183,7 +183,7 @@ public class GradedTestListenerJSON extends RunListener {
         currentTestResult.setScore(0);
         currentTestResult.addOutput("Test Failed: ");
         currentTestResult.addOutput(JUnitUtilities.failureToString(failure));
-	    currentTestResult.addOutput("\n");
+	  currentTestResult.addOutput("\n");
         //currentTestResult.addOutput(failure.getTrace());
     }
 

--- a/java/src/main/java/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
+++ b/java/src/main/java/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
@@ -181,8 +181,9 @@ public class GradedTestListenerJSON extends RunListener {
       */
     public void testFailure(Failure failure) throws Exception {
         currentTestResult.setScore(0);
-        currentTestResult.addOutput("Test Failed!\n");
-        System.out.println(JUnitUtilities.failureToString(failure));
+        currentTestResult.addOutput("Test Failed: ");
+        currentTestResult.addOutput(JUnitUtilities.failureToString(failure));
+	    currentTestResult.addOutput("\n");
         //currentTestResult.addOutput(failure.getTrace());
     }
 

--- a/java_template/src/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
+++ b/java_template/src/com/gradescope/jh61b/grader/GradedTestListenerJSON.java
@@ -181,8 +181,9 @@ public class GradedTestListenerJSON extends RunListener {
       */
     public void testFailure(Failure failure) throws Exception {
         currentTestResult.setScore(0);
-        currentTestResult.addOutput("Test Failed!\n");
-        System.out.println(JUnitUtilities.failureToString(failure));
+        currentTestResult.addOutput("Test Failed: ");
+        currentTestResult.addOutput(JUnitUtilities.failureToString(failure));
+	    currentTestResult.addOutput("\n");
         //currentTestResult.addOutput(failure.getTrace());
     }
 


### PR DESCRIPTION
When running tests with the GradedTestlistenerJSON attached, I noticed the output during a failed test sometimes includes the failed test's assertion error, along with the valid test result JSON. Since the java_template sample parses stdout to capture the result JSON, this extra message was breaking the autograder for failing tests.

Now, the error message is put into the JSOn output as a string, so no information is lost, rather just put in a different spot :)