### PR TITLE
Allows docker image to install monodevelop

### DIFF
--- a/c#/src/setup.sh
+++ b/c#/src/setup.sh
@@ -4,4 +4,4 @@ apt install apt-transport-https dirmngr
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb https://download.mono-project.com/repo/ubuntu vs-bionic main" | tee /etc/apt/sources.list.d/mono-official-vs.list
 apt-get update
-apt-get install -qy nunit nunit-console monodevelop
+apt-get install -qy nunit nunit-console monodevelop monodevelop-nunit

--- a/c#/src/setup.sh
+++ b/c#/src/setup.sh
@@ -1,7 +1,9 @@
 #! /bin./bash
 
-apt install apt-transport-https dirmngr
+apt-get update
+apt-get install -qy apt-transport-https dirmngr
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb https://download.mono-project.com/repo/ubuntu vs-bionic main" | tee /etc/apt/sources.list.d/mono-official-vs.list
+
 apt-get update
 apt-get install -qy nunit nunit-console monodevelop monodevelop-nunit

--- a/c#/src/setup.sh
+++ b/c#/src/setup.sh
@@ -1,4 +1,7 @@
 #! /bin./bash
 
+apt install apt-transport-https dirmngr
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb https://download.mono-project.com/repo/ubuntu vs-bionic main" | tee /etc/apt/sources.list.d/mono-official-vs.list
 apt-get update
 apt-get install -qy nunit nunit-console monodevelop


### PR DESCRIPTION
When trying to use nunit with mono, the image will still be missing some dependencies leading to gradescope being unable to find nunit.pc. This should fix it