### PR TITLE
Set top nav color to green

### DIFF
--- a/docs/gradescope.css
+++ b/docs/gradescope.css
@@ -1,3 +1,3 @@
-.wy-side-nav-search {
+.wy-side-nav-search, .wy-nav-top {
   background-color: #1b827f;
 }


### PR DESCRIPTION
The default color is fine, but we can change it to make it a little more Gradescope-y.

before:
<img height="300" src="https://user-images.githubusercontent.com/4902438/88083258-afb90700-cb37-11ea-9598-1f5fe424bb80.png" />
after:
<img height="300" src="https://user-images.githubusercontent.com/4902438/88083275-b2b3f780-cb37-11ea-8021-0f20758571e4.png" />
