### PR TITLE
Add pyyaml to diff_general dependencies

### DIFF
--- a/diff_general/requirements.txt
+++ b/diff_general/requirements.txt
@@ -1,2 +1,3 @@
 gradescope-utils>=0.2.6
 subprocess32
+pyyaml


### PR DESCRIPTION
This used to be in the base image but now it's not, since we upgraded the base image to use Python 3.

This sample should also be upgraded to use Python 3 but that's a slightly bigger task.