### PR TITLE
Add "Recent Changes" page with details about base image update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 [![Documentation Status](https://readthedocs.org/projects/gradescope-autograders/badge/?version=latest)](https://gradescope-autograders.readthedocs.org/en/latest/?badge=latest)
 
+> **🗞️ Our autograder platform is in active development! See the [Recent Changes](changes/) page to see what we've updated recently.**
+
 # Overview
 
 Gradescope provides a language-agnostic platform for running your

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 [![Documentation Status](https://readthedocs.org/projects/gradescope-autograders/badge/?version=latest)](https://gradescope-autograders.readthedocs.org/en/latest/?badge=latest)
 
-> **🗞️ Our autograder platform is in active development! See the [Recent Changes](changes/) page to see what we've updated recently.**
-
 # Overview
 
 Gradescope provides a language-agnostic platform for running your
@@ -12,6 +10,10 @@ assignments. You provide us with a setup script and an autograder
 script, along with whatever supporting code you need, and we manage
 accepting student submissions, running your autograder at scale, and
 distributing the results back to students and to you.
+
+!!! note "Updates"
+    Our autograder platform is under active development! Check out the
+    [Recent Changes](changes/) page to see what we've updated recently.
 
 # How it works
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ distributing the results back to students and to you.
 
 !!! note "Updates"
     Our autograder platform is under active development! Check out the
-    [Recent Changes](changes/) page to see what we've updated recently.
+    [Updates](updates/) page to see what we've changed recently.
 
 # How it works
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,10 +2,6 @@
 
 Here are some recent changes to our autograder platform. If you have any questions or issues with any of these changes, please email [help@gradescope.com](mailto:help@gradescope.com).
 
-## December 29th, 2020
-
-- The Ubuntu base image was upgraded from Ubuntu 18.04 LTS fo Ubuntu 20.04 LTS.
-
 ## September 4th, 2020
 
 - The Ubuntu, Fedora, and CentOS base images had their default Python installation upgraded from Python 2 to Python 3.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,12 @@
+# News and Updates
+
+Here are some recent changes to our autograder platform. If you have any questions or issues with any of these changes, please email [help@gradescope.com](mailto:help@gradescope.com).
+
+## December 29th, 2020
+
+- The Ubuntu base image was upgraded from Ubuntu 18.04 LTS fo Ubuntu 20.04 LTS.
+
+## September 4th, 2020
+
+- The Ubuntu, Fedora, and CentOS base images had their default Python installation upgraded from Python 2 to Python 3.
+	- See our [help documentation](../python3_issues/) if you suspect this is causing issues with your autograder setup.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,6 +1,6 @@
-# News and Updates
+# Updates
 
-Here are some recent changes to our autograder platform. If you have any questions or issues with any of these changes, please email [help@gradescope.com](mailto:help@gradescope.com).
+Here are some updates we've made to our autograder platform. If you have any questions or issues with any of these changes, please email [help@gradescope.com](mailto:help@gradescope.com).
 
 ## September 4th, 2020
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme: readthedocs
 extra_css: [gradescope.css]
 pages:
 - 'Home': index.md
+- 'Recent Changes': changes.md
 - 'Getting Started': getting_started.md
 - 'Autograder Specifications': specs.md
 - 'Manual Grading': manual_grading.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ theme: readthedocs
 extra_css: [gradescope.css]
 pages:
 - 'Home': index.md
-- 'Recent Changes': changes.md
+- 'Updates': updates.md
 - 'Getting Started': getting_started.md
 - 'Autograder Specifications': specs.md
 - 'Manual Grading': manual_grading.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,3 +27,5 @@ pages:
     - 'Native code via Python': diff.md
     - 'MySQL': mysql.md
 - 'Community Resources': resources.md
+markdown_extensions:
+  - admonition


### PR DESCRIPTION
This includes a mostly generic message (and _experimental_ emoji) at the top of the index; I wasn't sure we should include any specifics, since it'd be easy to forget to change that message moving forward if we add new things to the changelog. Open to input of course @ibrahima 

Preview visible at https://gradescope-autograders.readthedocs.io/en/tim-ch34758-document-the-upgrade-to-ubuntu-20-04-in-the/