### PR TITLE
Fix link to python3 issues doc

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -5,4 +5,4 @@ Here are some updates we've made to our autograder platform. If you have any que
 ## September 4th, 2020
 
 - The Ubuntu, Fedora, and CentOS base images had their default Python installation upgraded from Python 2 to Python 3.
-	- See our [help documentation](../python3_issues/) if you suspect this is causing issues with your autograder setup.
+	- See our [help documentation](python3_issues) if you suspect this is causing issues with your autograder setup.


### PR DESCRIPTION
If you visit https://gradescope-autograders.readthedocs.io/en/latest/updates/, the "help documentation" link is going to https://gradescope-autograders.readthedocs.io/en/python3_issues/ but it needs to go to https://gradescope-autograders.readthedocs.io/en/latest/python3_issues/

Running this in local server via mkdocs will result in a broken link, but I believe this would be the correct link on readthedocs. 

I think this (`[help documentation](python3_issues)`) is the right syntax? I'm matching the syntax in https://github.com/gradescope/autograder_samples/blob/master/docs/manual_docker.md (`[specifications](specs)`)

https://user-images.githubusercontent.com/4053800/106690417-9da82e80-6586-11eb-9a3e-fe166c0bbeeb.mp4

