### PR TITLE
Explain defaultTestLoader.discover

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -56,7 +56,7 @@ JSONTestRunner().run(suite)
 
 This will load tests from the `tests/` directory in your autograder source code,
 [loading only files starting with `test` by default](https://docs.python.org/3/library/unittest.html#unittest.TestLoader.discover).
-`JSONTestRunner` included in `gradescope-utils`, as described below.
+`JSONTestRunner` is included in `gradescope-utils`, as described below.
 
 # Files
 

--- a/python/README.md
+++ b/python/README.md
@@ -54,6 +54,10 @@ JSONTestRunner().run(suite)
 
 ```
 
+This will load tests from the `tests/` directory in your autograder source code,
+[loading only files starting with `test` by default](https://docs.python.org/3/library/unittest.html#unittest.TestLoader.discover).
+`JSONTestRunner` included in `gradescope-utils`, as described below.
+
 # Files
 
 ## [setup.sh](https://github.com/gradescope/autograder_samples/blob/master/python/src/setup.sh)


### PR DESCRIPTION
We had a support request from someone who didn't realize that test files needed to be prefixed with `test`, so I thought it'd be good to document this.