### PR TITLE
Remove extra padding from version switcher

### DIFF
--- a/docs/gradescope.css
+++ b/docs/gradescope.css
@@ -1,3 +1,8 @@
 .wy-side-nav-search, .wy-nav-top {
   background-color: #1b827f;
 }
+
+/* Hack around overlapping padding issue */
+.rst-versions .rst-current-version {
+  padding: 0 12px !important;
+}


### PR DESCRIPTION
This seems to be causing the version switcher to overlap sidebar links.