### PR TITLE
[GSC-5051] Add documentation on the new formatting options to autograders

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -152,7 +152,7 @@ an example below:
 
 ### Output String Formatting
 
-You can now add rich formatting to your autograder output to further
+You can add rich formatting to your autograder output to further
 customize your autograder experience for students.
 
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -40,6 +40,9 @@ Your autograder's output should be in the file results.json, in the following fo
 { "score": 44.0, // optional, but required if not on each test case below. Overrides total of tests if specified.
   "execution_time": 136, // optional, seconds
   "output": "Text relevant to the entire submission", // optional
+  "output_format": "simple_format", // Optional output format settings, see "Output String Formatting" below
+  "test_output_format": "text", // Optional default output format for test case outputs, see "Output String Formatting" below
+  "test_name_format": "text", // Optional default output format for test case names, see "Output String Formatting" below
   "visibility": "after_due_date", // Optional visibility setting
   "stdout_visibility": "visible", // Optional stdout visibility setting
   "extra_data": {}, // Optional extra data to be stored
@@ -50,8 +53,10 @@ Your autograder's output should be in the file results.json, in the following fo
             "max_score": 2.0, // optional
             "status": "passed", // optional, see "Test case status" below
             "name": "Your name here", // optional
+            "name_format": "text", // optional formatting for the test case name, see "Output String Formatting" below
             "number": "1.1", // optional (will just be numbered in order of array if no number given)
             "output": "Giant multiline string that will be placed in a <pre> tag and collapsed by default", // optional
+            "output_format": "text", // optional formatting for the test case output, see "Output String Formatting" below
             "tags": ["tag1", "tag2", "tag3"], // optional
             "visibility": "visible", // Optional visibility setting
             "extra_data": {} // Optional extra data to be stored
@@ -145,6 +150,24 @@ an example below:
 
 [<img src="../test_status.png" width="1253px" />](test_status.png)
 
+### Output String Formatting
+
+You can now add rich formatting to your autograder output to further
+customize your autograder experience for students.
+
+
+Options for the the format field are as follows:
+
+* `"text"` (default for test output and names) - This will do the
+basic text formatting which was previously done on all test names
+and outputs. No html, markdown, or ansi will be rendered.
+* `"simple_format"` (default for top level output) - This is very
+similar to the `"html"` format option but will also convert `\n`
+into `<br />` and `\n\n+` into a page break.
+* `"html"` - This will render html in your output. Note that we sanitize out
+so you may not be able to use all of the normal html elements!
+* `"md"` - This will render some basic markdown in your output.
+* `"ansi"` - This will render ansi colors similar to how the stdout renders them.
 ### Leaderboards
 
 You can add a "leaderboard" section to create leaderboards for your

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -160,13 +160,13 @@ Options for the the format field are as follows:
 
 * `"text"` (default for test output and names) - This will do the
 basic text formatting which was previously done on all test names
-and outputs. No html, markdown, or ansi will be rendered.
-* `"simple_format"` (default for top level output) - This is very
+and outputs. No HTML, Markdown, or ANSI will be rendered.
+* `"html"` - This will render HTML in your output. Note that we sanitize the
+output so you may not be able to use all HTML elements. Additionally, not all
+tags will be styled out of the box.
+* `"simple_format"` (default for top-level output) - This is very
 similar to the `"html"` format option but will also convert `\n`
 into `<br />` and `\n\n+` into a page break.
-* `"html"` - This will render html in your output. Note that we sanitize the
-output so you may not be able to use all html elements! Additionally, not all
-tags will be styled out of the box.
 * `"md"` - This will render some basic markdown in your output.
 * `"ansi"` - This will render ansi colors similar to how the stdout renders them.
 ### Leaderboards

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -167,8 +167,8 @@ tags will be styled out of the box.
 * `"simple_format"` (default for top-level output) - This is very
 similar to the `"html"` format option but will also convert `\n`
 into `<br />` and `\n\n+` into a page break.
-* `"md"` - This will render some basic markdown in your output.
-* `"ansi"` - This will render ansi colors similar to how the stdout renders them.
+* `"md"` - This will render some basic Markdown in your output.
+* `"ansi"` - This will render ANSI colors similar to how the stdout renders them.
 
 ### Leaderboards
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -164,8 +164,9 @@ and outputs. No html, markdown, or ansi will be rendered.
 * `"simple_format"` (default for top level output) - This is very
 similar to the `"html"` format option but will also convert `\n`
 into `<br />` and `\n\n+` into a page break.
-* `"html"` - This will render html in your output. Note that we sanitize out
-so you may not be able to use all of the normal html elements!
+* `"html"` - This will render html in your output. Note that we sanitize the
+output so you may not be able to use all html elements! Additionally, not all
+tags will be styled out of the box.
 * `"md"` - This will render some basic markdown in your output.
 * `"ansi"` - This will render ansi colors similar to how the stdout renders them.
 ### Leaderboards

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -169,6 +169,7 @@ similar to the `"html"` format option but will also convert `\n`
 into `<br />` and `\n\n+` into a page break.
 * `"md"` - This will render some basic markdown in your output.
 * `"ansi"` - This will render ansi colors similar to how the stdout renders them.
+
 ### Leaderboards
 
 You can add a "leaderboard" section to create leaderboards for your

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -2,6 +2,10 @@
 
 Here are some updates we've made to our autograder platform. If you have any questions or issues with any of these changes, please email [help@gradescope.com](mailto:help@gradescope.com).
 
+## Mar 22th, 2022
+
+We have added rich formatting options to the autograder output! See [our documentation on the formatting options here](../specs#output-string-formatting)
+
 ## Aug 16th, 2022
 
 We have added the ability to specify whether a test case should be considered to have passed or failed, overriding the default styling. See [our documentation on the results.json format](../specs#test-case-status) to learn more.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -6,6 +6,7 @@ Here are some updates we've made to our autograder platform. If you have any que
 
 We have added rich formatting options to the autograder output!
 See [our documentation on the formatting options here](../specs#output-string-formatting) for more information.
+
 ## Nov 8th, 2022
 
 We have upgraded `openssl` to 3.0.2-0ubuntu1.7 on Ubuntu 22.04 autograder base images.


### PR DESCRIPTION
Adds some documentation to the new formatting options in the autograder `results.json` file.