### PR TITLE
Update submission_metadata.md

### DIFF
--- a/docs/submission_metadata.md
+++ b/docs/submission_metadata.md
@@ -60,3 +60,8 @@ When implementing such schemes, be sure to compute time periods based
 on the current submission's "created_at" (submission time) -
 otherwise, re-running the autograder will cause the rate limits to be
 computed based on the current system time.
+
+We recommend only counting previous submissions when autograder_error
+is false. A true value for autograder_error communicates there was an
+autograder failure on the Gradescope side and should not be counted
+against the student.


### PR DESCRIPTION
Update submission counting logic to ignore failed autograder runs.

Previously, all past submissions could be counted, even when the Gradescope autograder had failed. Now we only count submissions where `autograder_error` is `false`.

- `autograder_error` is a flag that shows whether the Gradescope autograder had a failure.

- When `autograder_error` is `true`, it means there was a problem on the Gradescope side (for example, the grading program crashed or the system could not finish grading).

- These failures are not the student’s fault, so they should not reduce the number of attempts the student has left.

With this change:

- Submissions with `autograder_error = true` are not counted toward the student’s submission limit.

- Only submissions with` autograder_error = false` are treated as valid attempts.

**Example**

Submission 1: autograder_error = true → not counted

Submission 2: autograder_error = false → counted

Total counted submissions: 1

https://turnitin.atlassian.net/browse/GSC-6948